### PR TITLE
remove jest to enable npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-jest": "^24.1.3",
-    "jest": "^26.6.3",
     "np": "^7.2.0",
     "prettier": "^2.2.1",
     "sinon": "^9.2.3",


### PR DESCRIPTION
Clearly you won't want to actually remove jest, but just fix it. Unfortunately, I wasn't able to find a fix, so I just removed it to get things to install properly. I'm on node v12.20.1.

The error I got on the terminal:

![Screenshot from 2021-09-15 13-45-39](https://user-images.githubusercontent.com/2288939/133435972-ea061f01-7023-441e-a82d-5e1d2a5db44c.png)

The error in the logs:

![Screenshot from 2021-09-15 13-46-00](https://user-images.githubusercontent.com/2288939/133435989-f9fba006-be3f-4ef2-b6e4-c666077b71d0.png)
