### PR TITLE
adds HashChangeEvent type annotation

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -61,7 +61,7 @@ export const locationHashB = behaviorFromEvent<string, "hashchange", Window>(
   window,
   "hashchange",
   (w) => takeUntilRight("#", w.location.hash) || "/",
-  (evt) => takeUntilRight("#", evt.newURL)
+  (evt: HashChangeEvent) => takeUntilRight("#", evt.newURL)
 );
 
 export const locationB = behaviorFromEvent(


### PR DESCRIPTION
I got this error message on `npm run build`, and this fixes it for me. I'm on node v12.20.1.

![Screenshot from 2021-09-15 13-48-32](https://user-images.githubusercontent.com/2288939/133436516-58e2a39b-3976-475e-a54b-c5a763322c1e.png)
